### PR TITLE
Fix GetMatchingFontDescriptors overload with sort callback

### DIFF
--- a/src/CoreText/CTFontCollection.cs
+++ b/src/CoreText/CTFontCollection.cs
@@ -205,7 +205,7 @@ namespace CoreText {
 				if (cfArrayRef == IntPtr.Zero)
 					return new CTFontDescriptor [0];
 				var matches = NSArray.ArrayFromHandle (cfArrayRef,
-						fd => new CTFontDescriptor (cfArrayRef, false));
+						fd => new CTFontDescriptor (fd, false));
 				CFObject.CFRelease (cfArrayRef);
 				return matches;
 			}


### PR DESCRIPTION
It incorrectly returned array of arrays instead of array of CTFontDescriptors.